### PR TITLE
🌱 primitives/border: support irregular overflow in border

### DIFF
--- a/packages/primitives/border/src/index.web.tsx
+++ b/packages/primitives/border/src/index.web.tsx
@@ -34,7 +34,7 @@ export const Border = component(
     overflowLeft: 0,
     overflowRight: 0,
     overflowTop: 0,
-  }),
+  })
 )(({
   topLeftRadius,
   topRightRadius,

--- a/packages/primitives/border/src/index.web.tsx
+++ b/packages/primitives/border/src/index.web.tsx
@@ -13,7 +13,10 @@ export type TBorder = {
   rightWidth?: number,
   bottomWidth?: number,
   leftWidth?: number,
-  overflow?: number,
+  overflowBottom?: number,
+  overflowLeft?: number,
+  overflowRight?: number,
+  overflowTop?: number,
 }
 
 export const Border = component(
@@ -27,8 +30,11 @@ export const Border = component(
     rightWidth: 0,
     bottomWidth: 0,
     leftWidth: 0,
-    overflow: 0,
-  })
+    overflowBottom: 0,
+    overflowLeft: 0,
+    overflowRight: 0,
+    overflowTop: 0,
+  }),
 )(({
   topLeftRadius,
   topRightRadius,
@@ -39,15 +45,18 @@ export const Border = component(
   bottomWidth,
   leftWidth,
   color,
-  overflow,
+  overflowBottom,
+  overflowLeft,
+  overflowRight,
+  overflowTop,
 }) => (
   <Block
     shouldIgnorePointerEvents
     isFloating
-    top={-overflow}
-    right={-overflow}
-    bottom={-overflow}
-    left={-overflow}
+    top={-overflowTop}
+    right={-overflowRight}
+    bottom={-overflowBottom}
+    left={-overflowLeft}
     style={{
       borderTopLeftRadius: topLeftRadius,
       borderTopRightRadius: topRightRadius,


### PR DESCRIPTION
Interactive header in cell needs a keyboard focus boarder that is not even on every side, and it seems like the right solution to do to support it on the primitive level.

![image](https://user-images.githubusercontent.com/13185981/61467401-d5875b00-a97b-11e9-9720-a843c41c4e7d.png)
