### PR TITLE
Set table layout in Table to 'fixed' and add textAlign prop to Text

### DIFF
--- a/packages/primitives/table/src/Table.tsx
+++ b/packages/primitives/table/src/Table.tsx
@@ -24,8 +24,7 @@ export const Table = component(
       flexGrow: 1,
       flexShrink: 1,
       alignSelf: 'stretch',
-      maxWidth: '100%',
-      minWidth: 0,
+      width: '100%',
       padding: 0,
       borderColor,
       backgroundColor,
@@ -34,6 +33,7 @@ export const Table = component(
       borderLeftWidth: `${borderLeftWidth}px`,
       borderRightWidth: `${borderRightWidth}px`,
       borderStyle,
+      tableLayout: 'fixed',
     }),
   }), ['borderTopWidth', 'borderLeftWidth', 'borderRightWidth', 'borderBottomWidth', 'borderStyle', 'borderColor', 'backgroundColor'])
 )(({ id, children, style }) => (

--- a/packages/primitives/text/src/Root.web.tsx
+++ b/packages/primitives/text/src/Root.web.tsx
@@ -30,6 +30,7 @@ export const Text = component(
     shouldPreventSelection,
     shouldPreventWrap,
     shouldHideOverflow,
+    textAlign,
   }) => {
     const style: TStyle = {
       color,
@@ -74,6 +75,12 @@ export const Text = component(
 
     if (isUnderlined) {
       style.textDecoration = 'underline'
+    }
+
+    if (textAlign === 'right') {
+      style.textAlign = 'right'
+      style.display = 'block'
+      style.width = '100%'
     }
 
     return {

--- a/packages/primitives/text/src/types.ts
+++ b/packages/primitives/text/src/types.ts
@@ -13,4 +13,5 @@ export type TTextProps = {
   shouldPreventWrap?: boolean,
   shouldPreventSelection?: boolean,
   shouldHideOverflow?: boolean,
+  textAlign?: string,
 }


### PR DESCRIPTION
**Table**
Added `table-layout: fixed` and set `width:100%` in order to be able to truncate text inside cells.

**Text**
allow to align text to right with new prop `alignText`, to be able to align long text to right:
