### PR TITLE
🐞 primitives/table: add missing 'react-native' target in table

### DIFF
--- a/packages/primitives/table/package.json
+++ b/packages/primitives/table/package.json
@@ -3,8 +3,9 @@
   "version": "0.5.0",
   "description": "",
   "keywords": [],
-  "main": "src/index.web.tsx",
-  "browser": "src/index.web.tsx",
+  "main": "src/index.web.ts",
+  "browser": "src/index.web.ts",
+  "react-native": "src/index.native.ts",
   "repository": "bubble-dev/_",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Add missing 'react-native' target in 'package.json' for table