### PR TITLE
🌱 primitives/layout: adding flexbasis to layout in flow to enable hav…

### DIFF
--- a/packages/primitives/layout/src/InFlow.native.tsx
+++ b/packages/primitives/layout/src/InFlow.native.tsx
@@ -28,9 +28,12 @@ export const LayoutInFlow = component(
     let wrappedChildren = children
 
     if (direction === 'horizontal') {
-      if (width === 'stretch') {
+      if (width === 'stretch' || width === 'equal') {
         style.flexGrow = 1
         style.flexShrink = 1
+        if (width === 'equal') {
+          style.flexBasis = 0
+        }
       } else if (isNumber(width)) {
         style.width = width
       } else {

--- a/packages/primitives/layout/src/InFlow.native.tsx
+++ b/packages/primitives/layout/src/InFlow.native.tsx
@@ -28,12 +28,13 @@ export const LayoutInFlow = component(
     let wrappedChildren = children
 
     if (direction === 'horizontal') {
-      if (width === 'stretch' || width === 'equal') {
+      if (width === 'stretch') {
         style.flexGrow = 1
         style.flexShrink = 1
-        if (width === 'equal') {
-          style.flexBasis = 0
-        }
+      } else if (width === 'equal') {
+        style.flexGrow = 1
+        style.flexShrink = 1
+        style.flexBasis = 0
       } else if (isNumber(width)) {
         style.width = width
       } else {

--- a/packages/primitives/layout/src/InFlow.web.tsx
+++ b/packages/primitives/layout/src/InFlow.web.tsx
@@ -28,9 +28,12 @@ export const LayoutInFlow = component(
     }
 
     if (direction === 'horizontal') {
-      if (width === 'stretch') {
+      if (width === 'stretch' || width === 'equal') {
         style.flexGrow = 1
         style.flexShrink = 1
+        if (width === 'equal') {
+          style.flexBasis = 0
+        }
       } else if (isNumber(width)) {
         style.width = width
       }

--- a/packages/primitives/layout/src/InFlow.web.tsx
+++ b/packages/primitives/layout/src/InFlow.web.tsx
@@ -28,12 +28,13 @@ export const LayoutInFlow = component(
     }
 
     if (direction === 'horizontal') {
-      if (width === 'stretch' || width === 'equal') {
+      if (width === 'stretch') {
         style.flexGrow = 1
         style.flexShrink = 1
-        if (width === 'equal') {
-          style.flexBasis = 0
-        }
+      } else if (width === 'equal') {
+        style.flexGrow = 1
+        style.flexShrink = 1
+        style.flexBasis = 0
       } else if (isNumber(width)) {
         style.width = width
       }

--- a/packages/primitives/layout/src/types.ts
+++ b/packages/primitives/layout/src/types.ts
@@ -23,7 +23,7 @@ export type TLayout = {
 }
 
 export type TLayoutInFlow = {
-  width?: number | 'stretch',
+  width?: number | 'stretch' | 'equal',
   height?: number | 'stretch',
   minWidth?: number,
   maxWidth?: number,


### PR DESCRIPTION
the idea is to allowed the user to have items with equal width sizes
from:
<img width="303" alt="Screen Shot 2019-10-29 at 11 24 05" src="https://user-images.githubusercontent.com/16437281/67758868-c44fef00-fa3e-11e9-9e22-5c0b3db3f7b8.png">

to:
<img width="266" alt="Screen Shot 2019-10-29 at 11 24 47" src="https://user-images.githubusercontent.com/16437281/67758880-c914a300-fa3e-11e9-9cf9-82b9466992fe.png">
