### PR TITLE
🌱 primitives/link: add support to `rel` attribute on `<a>`

### DIFF
--- a/packages/primitives/link/src/Root.web.tsx
+++ b/packages/primitives/link/src/Root.web.tsx
@@ -19,6 +19,7 @@ export const Link: FC<TLink> = ({
   onPress,
   onPressIn,
   onPressOut,
+  rel,
 }) => (
   <a
     href={href}
@@ -33,6 +34,7 @@ export const Link: FC<TLink> = ({
     style={style}
     tabIndex={tabIndex}
     target={target}
+    rel={rel}
   >
     {children}
   </a>

--- a/packages/primitives/link/src/types.ts
+++ b/packages/primitives/link/src/types.ts
@@ -19,6 +19,7 @@ export type TLink = {
   target?: string,
   tabIndex?: number,
   children?: ReactNode,
+  rel?: string,
   onPress?: () => void,
 } & TIsHoveredHandlers
   & TIsPressedHandlers


### PR DESCRIPTION
For security reasons, it's important to being able to set `rel` attribute on `<a>` when linking to an external domain.

For now, keeping type as a loose `string` and optional

We could even consider requiring `rel`  whenever `target="_blank"` or even set its default to`rel="noopener noreferrer"` at such case, for example. Thoughts?
