### PR TITLE
🌱 primitives/layout: layout can receive reverse as direction

### DIFF
--- a/packages/primitives/layout/src/Root.web.tsx
+++ b/packages/primitives/layout/src/Root.web.tsx
@@ -37,8 +37,8 @@ export const Layout = component(
       minHeight,
     }
 
-    if (direction === 'horizontal') {
-      style.flexDirection = 'row'
+    if (direction === 'horizontal' || direction === 'horizontal-reverse') {
+      style.flexDirection = direction === 'horizontal' ? 'row' : 'row-reverse'
 
       switch (hAlign) {
         case 'left': {
@@ -75,8 +75,8 @@ export const Layout = component(
           break
         }
       }
-    } else if (direction === 'vertical') {
-      style.flexDirection = 'column'
+    } else if (direction === 'vertical' || direction === 'vertical-reverse') {
+      style.flexDirection = direction === 'vertical' ? 'column' : 'column-reverse'
 
       switch (hAlign) {
         case 'left': {

--- a/packages/primitives/layout/src/types.ts
+++ b/packages/primitives/layout/src/types.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export type TLayoutDirection = 'horizontal' | 'vertical'
+export type TLayoutDirection = 'horizontal' | 'vertical' | 'horizontal-reverse' | 'vertical-reverse'
 
 export type TContextData = {
   direction: TLayoutDirection,


### PR DESCRIPTION
just an idea, currently it can be very useful for me in case like:

we want to have:
icon - spacer - text
but also:
text - spacer - icon

WDYT?


<img width="250" alt="Screenshot 2020-01-10 at 17 31 05" src="https://user-images.githubusercontent.com/16437281/72169251-0b5b4880-33cf-11ea-9a83-1f130c0d7afc.png">
