### PR TITLE
🌱 start: add support for namespaces

### DIFF
--- a/packages/start/cli/src/lib.ts
+++ b/packages/start/cli/src/lib.ts
@@ -7,6 +7,20 @@ type TStartOptions = {
   require?: (string | [string, { [k: string]: any }])[],
 }
 
+const getTasksNames = (tasks: any, namespace?: string, tasksNames: string[] = []) => {
+  for (const [taskName, task] of Object.entries(tasks)) {
+    const path = `${namespace === undefined ? '' : `${namespace}.`}${taskName}`
+
+    if (typeof task === 'function') {
+      tasksNames.push(path)
+    }
+
+    getTasksNames(task, path, tasksNames)
+  }
+
+  return tasksNames
+}
+
 export default async (argv: string[], options: TStartOptions) => {
   if (!options.reporter) {
     throw '`reporter` option is missing in your `package.json` → `start`'
@@ -16,10 +30,12 @@ export default async (argv: string[], options: TStartOptions) => {
   const tasksToRequire = options.preset || resolve(tasksFile)
   const tasks = await import(tasksToRequire)
   const taskName = argv[2]
-  const task = tasks[taskName]
+  const task = taskName?.split('.').reduce((tasks, taskName) =>
+    tasks && Object.prototype.hasOwnProperty.call(tasks, taskName) && tasks[taskName]
+  , tasks)
 
-  if (typeof taskName === 'undefined' || typeof task === 'undefined') {
-    throw `One of the following task names is required:\n* ${Object.keys(tasks).join('\n* ')}`
+  if (typeof task !== 'function') {
+    throw `One of the following task names is required:\n* ${getTasksNames(tasks).join('\n* ')}`
   }
 
   const taskArgs = argv.slice(3)


### PR DESCRIPTION
Used dot as a delimiter, but maybe it should be colon instead (similar to other task managers).