### PR TITLE
[Primitives/text] add support for semantic roles

### DIFF
--- a/packages/primitives/text/package.json
+++ b/packages/primitives/text/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@themeables/text": "^1.0.0",
     "colorido": "^1.0.0",
+    "elegir": "^1.0.0",
     "refun": "^1.0.0",
     "stili": "^1.0.0",
     "tsfn": "^1.0.0"

--- a/packages/primitives/text/package.json
+++ b/packages/primitives/text/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@themeables/text": "^1.0.0",
     "colorido": "^1.0.0",
-    "elegir": "^1.0.0",
     "refun": "^1.0.0",
     "stili": "^1.0.0",
     "tsfn": "^1.0.0"

--- a/packages/primitives/text/src/Root.native.tsx
+++ b/packages/primitives/text/src/Root.native.tsx
@@ -18,6 +18,7 @@ export const Text = component(
     shouldPreventWrap: false,
     shouldHideOverflow: false,
     isUnderlined: false,
+    isItalic: false,
   }),
   mapWithProps(({
     color,
@@ -25,6 +26,7 @@ export const Text = component(
     lineHeight,
     fontFamily,
     fontWeight,
+    isItalic,
     fontSize,
     isUnderlined,
     shouldPreventSelection,
@@ -36,6 +38,7 @@ export const Text = component(
       lineHeight,
       fontFamily,
       fontWeight,
+      fontStyle: isItalic ? 'italic' : 'normal',
       fontSize,
       letterSpacing,
     }

--- a/packages/primitives/text/src/Root.web.tsx
+++ b/packages/primitives/text/src/Root.web.tsx
@@ -8,7 +8,6 @@ import {
 } from 'refun'
 import { isNumber } from 'tsfn'
 import { colorToString, isColor } from 'colorido'
-import { elegir } from 'elegir'
 import { TText } from './types'
 
 export const Text = component(
@@ -19,6 +18,7 @@ export const Text = component(
     shouldPreventWrap: false,
     shouldHideOverflow: false,
     isUnderlined: false,
+    isItalic: false,
     role: 'none',
   }),
   mapWithProps(({
@@ -28,6 +28,7 @@ export const Text = component(
     fontFamily,
     fontWeight,
     fontSize,
+    isItalic,
     isUnderlined,
     shouldPreserveWhitespace,
     shouldPreventSelection,
@@ -39,6 +40,7 @@ export const Text = component(
       fontFamily,
       fontWeight,
       fontSize,
+      fontStyle: isItalic ? 'italic' : 'normal',
       fontSmoothing: 'antialiased',
       textRendering: 'geometricPrecision',
       textSizeAdjust: 'none',
@@ -91,20 +93,21 @@ export const Text = component(
       style: normalizeStyle(style),
     }
   })
-)(({ children, style, id, role }) => (
-  elegir(
-    role === 'paragraph',
-    <p id={id} style={style}>{children}</p>,
+)(({ children, style, id, role }) => {
+  switch (role) {
+    case 'paragraph':
+      return <p id={id} style={style}>{children}</p>
 
-    role === 'important',
-    <strong id={id} style={style}>{children}</strong>,
+    case 'important':
+      return <strong id={id} style={style}>{children}</strong>
 
-    role === 'emphasis',
-    <em id={id} style={style}>{children}</em>,
+    case 'emphasis':
+      return <em id={id} style={style}>{children}</em>
 
-    role === 'none' || true,
-    <span id={id} style={style}>{children}</span>
-  )
-))
+    case 'none':
+    default:
+      return <span id={id} style={style}>{children}</span>
+  }
+})
 
 Text.displayName = 'Text'

--- a/packages/primitives/text/src/Root.web.tsx
+++ b/packages/primitives/text/src/Root.web.tsx
@@ -8,6 +8,7 @@ import {
 } from 'refun'
 import { isNumber } from 'tsfn'
 import { colorToString, isColor } from 'colorido'
+import { elegir } from 'elegir'
 import { TText } from './types'
 
 export const Text = component(
@@ -18,6 +19,7 @@ export const Text = component(
     shouldPreventWrap: false,
     shouldHideOverflow: false,
     isUnderlined: false,
+    role: 'none',
   }),
   mapWithProps(({
     color,
@@ -31,6 +33,7 @@ export const Text = component(
     shouldPreventSelection,
     shouldPreventWrap,
     shouldHideOverflow,
+    role,
   }) => {
     const style: TStyle = {
       fontFamily,
@@ -80,12 +83,28 @@ export const Text = component(
       style.textDecoration = 'underline'
     }
 
+    if (role === 'paragraph') {
+      style.display = 'inline'
+    }
+
     return {
       style: normalizeStyle(style),
     }
   })
-)(({ children, style, id }) => (
-  <span id={id} style={style}>{children}</span>
+)(({ children, style, id, role }) => (
+  elegir(
+    role === 'paragraph',
+    <p id={id} style={style}>{children}</p>,
+
+    role === 'important',
+    <strong id={id} style={style}>{children}</strong>,
+
+    role === 'emphasis',
+    <em id={id} style={style}>{children}</em>,
+
+    role === 'none' || true,
+    <span id={id} style={style}>{children}</span>
+  )
 ))
 
 Text.displayName = 'Text'

--- a/packages/primitives/text/src/types.ts
+++ b/packages/primitives/text/src/types.ts
@@ -6,6 +6,7 @@ type TSupportedRoles = 'paragraph' | 'important' | 'emphasis' | 'none'
 export type TText = {
   id?: string,
   role?: TSupportedRoles,
+  isItalic?: boolean,
   shouldPreserveWhitespace?: boolean,
   shouldPreventWrap?: boolean,
   shouldPreventSelection?: boolean,

--- a/packages/primitives/text/src/types.ts
+++ b/packages/primitives/text/src/types.ts
@@ -1,8 +1,11 @@
 import { ReactNode } from 'react'
 import { TThemeableText } from '@themeables/text'
 
+type TSupportedRoles = 'paragraph' | 'important' | 'emphasis' | 'none'
+
 export type TText = {
   id?: string,
+  role?: TSupportedRoles,
   shouldPreserveWhitespace?: boolean,
   shouldPreventWrap?: boolean,
   shouldPreventSelection?: boolean,

--- a/packages/stili/src/index.native.ts
+++ b/packages/stili/src/index.native.ts
@@ -5,6 +5,7 @@ type TCssProps = TExtend<ImageStyle, TextStyle>
 
 export type TStyle = TExtend<TCssProps, {
   fontWeight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900,
+  fontSize?: number,
 }>
 
 export const normalizeStyle = (style: TStyle): TCssProps =>

--- a/packages/stili/src/index.web.ts
+++ b/packages/stili/src/index.web.ts
@@ -5,6 +5,7 @@ export type TStyle = TExtend<CSSProperties, {
   fontSmoothing?: string,
   tapHighlightColor?: string,
   fontWeight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900,
+  fontSize?: number,
 }>
 
 type TCssProps = TExtend<CSSProperties, {


### PR DESCRIPTION
Adding the `role` property allow us to output for semantically correct and accessible code for web. Native is unaffected because there aren't `accessibilityRoles` for `<Text>` in React Native at this point.