### PR TITLE
Add scale to vector shape

### DIFF
--- a/packages/primitives/vector-shape/meta.tsx
+++ b/packages/primitives/vector-shape/meta.tsx
@@ -9,11 +9,11 @@ export const config: TComponentConfig<TVectorShape> = {
     ],
     path: [
       'M0,50 L0,50 L50,100 L100,50 L50,0 L0,50 Z',
-      'M0,30 L0,30 L30,80 L80,30 L30,0 L0,30 Z'
+      'M0,30 L0,30 L30,80 L80,30 L30,0 L0,30 Z',
     ],
     height: [100, 80],
     width: [100, 80],
-    scale: [1, 2.2, 0.5]
+    scale: [1, 2.2, 0.5],
   },
   required: ['color', 'path', 'height', 'width'],
 }

--- a/packages/primitives/vector-shape/meta.tsx
+++ b/packages/primitives/vector-shape/meta.tsx
@@ -7,11 +7,17 @@ export const config: TComponentConfig<TVectorShape> = {
       [0xFF, 0x00, 0x00, 1],
       [0x00, 0xFF, 0x00, 1],
     ],
-    path: ['M0,50 L0,50 L50,100 L100,50 L50,0 L0,50 Z'],
-    height: [100],
-    width: [100],
+    path: [
+      'M0,50 L0,50 L50,100 L100,50 L50,0 L0,50 Z',
+      'M0,30 L0,30 L30,80 L80,30 L30,0 L0,30 Z'
+    ],
+    height: [100, 80],
+    width: [100, 80],
+    scale: [1, 2.2, 0.5]
   },
   required: ['color', 'path', 'height', 'width'],
 }
 
 export { VectorShape as Component } from './src'
+
+export { default as packageJson } from './package.json'

--- a/packages/primitives/vector-shape/package.json
+++ b/packages/primitives/vector-shape/package.json
@@ -16,7 +16,9 @@
     "@primitives/block": "1.1.0",
     "@primitives/svg": "1.0.1",
     "@themeables/vector-shape": "^1.0.0",
-    "colorido": "^1.0.0"
+    "colorido": "^1.0.0",
+    "refun": "^1.0.0",
+    "stili": "^1.1.0"
   },
   "devDependencies": {
     "@types/react": "^16.8.6",

--- a/packages/primitives/vector-shape/src/Root.native.tsx
+++ b/packages/primitives/vector-shape/src/Root.native.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { View } from '@primitives/view'
+import { Block } from '@primitives/block'
 import { component, startWithType, mapWithProps, mapDefaultProps } from 'refun'
 import { Surface, Shape } from '@primitives/svg'
 import { colorToString } from 'colorido'
 import { TVectorShape } from './types'
-import { normalizeStyle } from 'stili'
 
 export const VectorShape = component(
   startWithType<TVectorShape>(),
@@ -19,20 +18,20 @@ export const VectorShape = component(
     }
 
     return {
-      style: normalizeStyle({
+      style: {
         transform,
-      }),
+      },
     }
   })
 )(({ color, height, id, path, style, width }) => (
-  <View style={style}>
+  <Block shouldIgnorePointerEvents style={style}>
     <Surface id={id} height={height} width={width}>
       <Shape
         d={path}
         fill={colorToString(color)}
       />
     </Surface>
-  </View>
+  </Block>
 ))
 
 VectorShape.displayName = 'VectorShape'

--- a/packages/primitives/vector-shape/src/Root.native.tsx
+++ b/packages/primitives/vector-shape/src/Root.native.tsx
@@ -1,1 +1,38 @@
-Root.web.tsx
+import React from 'react'
+import { View } from '@primitives/view'
+import { component, startWithType, mapWithProps, mapDefaultProps } from 'refun'
+import { Surface, Shape } from '@primitives/svg'
+import { colorToString } from 'colorido'
+import { TVectorShape } from './types'
+import { normalizeStyle } from 'stili'
+
+export const VectorShape = component(
+  startWithType<TVectorShape>(),
+  mapDefaultProps({
+    color: [0, 0, 0, 1],
+  }),
+  mapWithProps(({ scale }) => {
+    const transform = []
+
+    if (typeof scale !== 'undefined') {
+      transform.push({ scale })
+    }
+
+    return {
+      style: normalizeStyle({
+        transform,
+      }),
+    }
+  })
+)(({ color, height, id, path, style, width }) => (
+  <View style={style}>
+    <Surface id={id} height={height} width={width}>
+      <Shape
+        d={path}
+        fill={colorToString(color)}
+      />
+    </Surface>
+  </View>
+))
+
+VectorShape.displayName = 'VectorShape'

--- a/packages/primitives/vector-shape/src/Root.web.tsx
+++ b/packages/primitives/vector-shape/src/Root.web.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { View } from '@primitives/view'
+import { Block } from '@primitives/block'
 import { component, startWithType, mapWithProps, mapDefaultProps } from 'refun'
 import { Surface, Shape } from '@primitives/svg'
 import { colorToString } from 'colorido'
+import { TStyle } from 'stili'
 import { TVectorShape } from './types'
-import { normalizeStyle, TStyle } from 'stili'
 
 export const VectorShape = component(
   startWithType<TVectorShape>(),
@@ -17,11 +17,7 @@ export const VectorShape = component(
     let transform = ''
 
     if (typeof scale !== 'undefined') {
-      if (transform.length > 0) {
-        transform += ' '
-      }
-
-      transform += `scale(${scale}, ${scale})`
+      transform += `scale(${scale})`
     }
 
     if (transform.length > 0) {
@@ -29,18 +25,18 @@ export const VectorShape = component(
     }
 
     return {
-      style: normalizeStyle(style),
+      style,
     }
   })
 )(({ color, height, id, path, style, width }) => (
-  <View style={style}>
+  <Block shouldIgnorePointerEvents style={style}>
     <Surface id={id} height={height} width={width}>
       <Shape
         d={path}
         fill={colorToString(color)}
       />
     </Surface>
-  </View>
+  </Block>
 ))
 
 VectorShape.displayName = 'VectorShape'

--- a/packages/primitives/vector-shape/src/Root.web.tsx
+++ b/packages/primitives/vector-shape/src/Root.web.tsx
@@ -1,18 +1,46 @@
-import React, { FC } from 'react'
-import { Block } from '@primitives/block'
+import React from 'react'
+import { View } from '@primitives/view'
+import { component, startWithType, mapWithProps, mapDefaultProps } from 'refun'
 import { Surface, Shape } from '@primitives/svg'
 import { colorToString } from 'colorido'
 import { TVectorShape } from './types'
+import { normalizeStyle, TStyle } from 'stili'
 
-export const VectorShape: FC<TVectorShape> = ({ color = [0, 0, 0, 1], height, id, path, width }) => (
-  <Block shouldIgnorePointerEvents>
+export const VectorShape = component(
+  startWithType<TVectorShape>(),
+  mapDefaultProps({
+    color: [0, 0, 0, 1],
+  }),
+  mapWithProps(({ scale }) => {
+    const style: TStyle = {}
+
+    let transform = ''
+
+    if (typeof scale !== 'undefined') {
+      if (transform.length > 0) {
+        transform += ' '
+      }
+
+      transform += `scale(${scale}, ${scale})`
+    }
+
+    if (transform.length > 0) {
+      style.transform = transform
+    }
+
+    return {
+      style: normalizeStyle(style),
+    }
+  })
+)(({ color, height, id, path, style, width }) => (
+  <View style={style}>
     <Surface id={id} height={height} width={width}>
       <Shape
         d={path}
         fill={colorToString(color)}
       />
     </Surface>
-  </Block>
-)
+  </View>
+))
 
 VectorShape.displayName = 'VectorShape'

--- a/packages/themeables/vector-shape/src/types.ts
+++ b/packages/themeables/vector-shape/src/types.ts
@@ -4,6 +4,7 @@ export type TThemeableVectorShape = {
   color?: TColor,
   height?: number,
   path: string,
+  scale?: number,
   width?: number,
 }
 

--- a/tasks/sandbox/components/index.native.ts
+++ b/tasks/sandbox/components/index.native.ts
@@ -3,9 +3,11 @@ import { TComponents } from '@sandbox/ui'
 import * as Button from '@primitives/button/meta'
 import * as Input from '@primitives/input/meta'
 import * as Checkbox from '@primitives/checkbox/meta'
+import * as VectorShape from '@primitives/vector-shape/meta'
 
 export const components: TComponents = {
   Button: () => Promise.resolve(Button),
   Input: () => Promise.resolve(Input),
   Checkbox: () => Promise.resolve(Checkbox),
+  VectorShape: () => Promise.resolve(VectorShape),
 }

--- a/tasks/sandbox/components/index.web.ts
+++ b/tasks/sandbox/components/index.web.ts
@@ -4,5 +4,6 @@ export const components: TComponents = {
   Button: () => import('@primitives/button/meta' /* webpackChunkName: "Button" */),
   Input: () => import('@primitives/input/meta' /* webpackChunkName: "Input" */),
   Checkbox: () => import('@primitives/checkbox/meta' /* webpackChunkName: "Checkbox" */),
+  VectorShape: () => import('@primitives/vector-shape/meta' /* webpackChunkName: "VectorShape" */),
 }
 


### PR DESCRIPTION
Add optional `scale` prop to VectorShape primitive and themeable.
Tested on web, iOS and Android.