### PR TITLE
Add text align themeable

### DIFF
--- a/packages/primitives/paragraph/package.json
+++ b/packages/primitives/paragraph/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@themeables/spacer": "^0.2.0",
     "@themeables/text": "^2.0.0",
+    "@themeables/text-align": "^0.0.0",
     "colorido": "^1.0.0",
     "refun": "^2.0.0",
     "stili": "^2.0.0"

--- a/packages/primitives/paragraph/src/types.ts
+++ b/packages/primitives/paragraph/src/types.ts
@@ -1,13 +1,9 @@
 import { ReactNode } from 'react'
 import { TThemeableText } from '@themeables/text'
 import { TThemeableSpacer } from '@themeables/spacer'
-
-export type TAlign = 'start' | 'center' | 'end'
-export type TDirection = 'left-to-right' | 'right-to-left'
+import { TThemeableTextAlign } from '@themeables/text-align'
 
 export type TParagraph = {
-  align?: TAlign,
-  direction?: TDirection,
   id?: string,
   shouldPreserveWhitespace?: boolean,
   shouldPreventWrap?: boolean,
@@ -16,3 +12,4 @@ export type TParagraph = {
   children: ReactNode,
 } & TThemeableText
   & TThemeableSpacer
+  & TThemeableTextAlign

--- a/packages/primitives/paragraph/src/types.ts
+++ b/packages/primitives/paragraph/src/types.ts
@@ -2,9 +2,12 @@ import { ReactNode } from 'react'
 import { TThemeableText } from '@themeables/text'
 import { TThemeableSpacer } from '@themeables/spacer'
 
+export type TAlign = 'start' | 'center' | 'end'
+export type TDirection = 'left-to-right' | 'right-to-left'
+
 export type TParagraph = {
-  align?: 'start' | 'center' | 'end',
-  direction?: 'left-to-right' | 'right-to-left',
+  align?: TAlign,
+  direction?: TDirection,
   id?: string,
   shouldPreserveWhitespace?: boolean,
   shouldPreventWrap?: boolean,

--- a/packages/themeables/text-align/meta.tsx
+++ b/packages/themeables/text-align/meta.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { TComponentConfig } from 'autoprops'
+import { TParagraph, Paragraph } from '@primitives/paragraph'
+import { setupTextAlignTheme, TThemeableTextAligns } from './src'
+
+type TDemo = {}
+
+type Mappings = {
+  demo: TDemo,
+}
+
+const defaultTheme: TThemeableTextAligns<Mappings> = {
+  demo: () => ({
+    align: 'start',
+    direction: 'left-to-right',
+  }),
+}
+
+const { TextAlignTheme, createThemeableTextAlign } = setupTextAlignTheme<Mappings>(defaultTheme)
+
+const DemoThemeableTextAlign = createThemeableTextAlign<TParagraph>('demo', Paragraph)
+
+const newTheme: TThemeableTextAligns<Mappings> = {
+  demo: () => ({
+    align: 'start',
+    direction: 'right-to-left',
+  }),
+}
+
+const text = 'Cat is love, cat is life fall asleep on the washing machine. Gnaw the corn cob. Meow to be let in cat walks in keyboard destroy couch as revenge.'
+
+type TDemoComponent = TDemo & { hasTheme: boolean }
+
+export const Component = ({ hasTheme }: TDemoComponent) => {
+  return (
+    hasTheme
+      ? (
+        <TextAlignTheme.Provider value={newTheme}>
+          <DemoThemeableTextAlign>
+            { text }
+          </DemoThemeableTextAlign>
+        </TextAlignTheme.Provider>
+      )
+      : (
+        <DemoThemeableTextAlign>
+          { text }
+        </DemoThemeableTextAlign>
+      )
+  )
+}
+
+Component.displayName = 'ThemeableTextAlign'
+
+export const config: TComponentConfig<TDemoComponent> = {
+  props: {
+    hasTheme: [true],
+  },
+}
+
+export { default as packageJson } from './package.json'

--- a/packages/themeables/text-align/meta.tsx
+++ b/packages/themeables/text-align/meta.tsx
@@ -3,7 +3,6 @@ import { TComponentConfig } from 'autoprops'
 import { TParagraph, Paragraph } from '@primitives/paragraph'
 import { setupTextAlignTheme, TThemeableTextAligns } from './src'
 
-
 type Mappings = {
   demo: {},
 }

--- a/packages/themeables/text-align/meta.tsx
+++ b/packages/themeables/text-align/meta.tsx
@@ -3,10 +3,9 @@ import { TComponentConfig } from 'autoprops'
 import { TParagraph, Paragraph } from '@primitives/paragraph'
 import { setupTextAlignTheme, TThemeableTextAligns } from './src'
 
-type TDemo = {}
 
 type Mappings = {
-  demo: TDemo,
+  demo: {},
 }
 
 const defaultTheme: TThemeableTextAligns<Mappings> = {
@@ -29,7 +28,7 @@ const newTheme: TThemeableTextAligns<Mappings> = {
 
 const text = 'Cat is love, cat is life fall asleep on the washing machine. Gnaw the corn cob. Meow to be let in cat walks in keyboard destroy couch as revenge.'
 
-type TDemoComponent = TDemo & { hasTheme: boolean }
+type TDemoComponent = { hasTheme: boolean }
 
 export const Component = ({ hasTheme }: TDemoComponent) => {
   return (

--- a/packages/themeables/text-align/package.json
+++ b/packages/themeables/text-align/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@themeables/text-align",
+  "version": "0.0.0",
+  "description": "",
+  "keywords": [],
+  "main": "src/index.ts",
+  "browser": "src/index.ts",
+  "react-native": "src/index.ts",
+  "repository": "bubble-dev/_",
+  "license": "MIT",
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "sideEffects": false,
+  "dependencies": {
+    "@babel/runtime": "^7.1.2",
+    "@themeables/core": "^2.0.0"
+  },
+  "devDependencies": {
+    "@primitives/paragraph": "^0.1.0",
+    "@types/react": "^16.8.6",
+    "autoprops": "^3.0.0",
+    "react": "16.13.1"
+  }
+}

--- a/packages/themeables/text-align/readme.md
+++ b/packages/themeables/text-align/readme.md
@@ -5,6 +5,9 @@
 Properties that the theme function for the `@themeables/text-align` should return:
 
 ```ts
+export type TAlign = 'start' | 'center' | 'end'
+export type TDirection = 'left-to-right' | 'right-to-left'
+
 type TThemeableTextAlign = {
   align?: TAlign,
   direction?: TDirection,

--- a/packages/themeables/text-align/readme.md
+++ b/packages/themeables/text-align/readme.md
@@ -1,0 +1,14 @@
+# @themeables/text
+
+> What is a _themeable_? You can find more in the [`@themeables` readme](..)
+
+Properties that the theme function for the `@themeables/text-align` should return:
+
+```ts
+type TThemeableTextAlign = {
+  align?: TAlign,
+  direction?: TDirection,
+}
+```
+
+You can see a full example usage in [the meta file](meta.tsx)

--- a/packages/themeables/text-align/src/index.ts
+++ b/packages/themeables/text-align/src/index.ts
@@ -1,0 +1,13 @@
+import { setupTheme, TThemeables } from '@themeables/core'
+import { TThemeableTextAlign } from './types'
+
+export * from './types'
+
+export const setupTextAlignTheme = <ComponentMappings>(defaultTheme: TThemeables<TThemeableTextAlign, ComponentMappings>) => {
+  const { ThemePiece, createThemeable } = setupTheme<TThemeableTextAlign, ComponentMappings>(defaultTheme)
+
+  return {
+    TextAlignTheme: ThemePiece,
+    createThemeableTextAlign: createThemeable,
+  }
+}

--- a/packages/themeables/text-align/src/types.ts
+++ b/packages/themeables/text-align/src/types.ts
@@ -1,4 +1,5 @@
-import { TAlign, TDirection } from '@primitives/paragraph'
+export type TAlign = 'start' | 'center' | 'end'
+export type TDirection = 'left-to-right' | 'right-to-left'
 
 export type TThemeableTextAlign = {
   align?: TAlign,

--- a/packages/themeables/text-align/src/types.ts
+++ b/packages/themeables/text-align/src/types.ts
@@ -1,0 +1,13 @@
+import { TAlign, TDirection } from '@primitives/paragraph'
+
+export type TThemeableTextAlign = {
+  align?: TAlign,
+  direction?: TDirection,
+}
+
+export type TThemeTextAlign<InputProps> = (props: InputProps) => TThemeableTextAlign
+
+export type TThemeableTextAligns<ComponentProps> = {
+  [key in keyof ComponentProps]: TThemeTextAlign<ComponentProps[key]>
+}
+

--- a/tasks/sandbox/components/index.native.ts
+++ b/tasks/sandbox/components/index.native.ts
@@ -5,6 +5,7 @@ import * as Checkbox from '@primitives/checkbox/meta'
 import * as Heading from '@primitives/heading/meta'
 import * as Input from '@primitives/input/meta'
 import * as LayoutThemeable from '@themeables/layout/meta'
+import * as TextAlignThemeable from '@themeables/text-align/meta'
 import * as Paragraph from '@primitives/paragraph/meta'
 import * as Radio from '@primitives/radio/meta'
 import * as Spacer from '@primitives/spacer/meta'
@@ -17,6 +18,7 @@ export const components: TComponents = {
   Heading: () => Promise.resolve(Heading),
   Input: () => Promise.resolve(Input),
   LayoutThemeable: () => Promise.resolve(LayoutThemeable),
+  TextAlignThemeable: () => Promise.resolve(TextAlignThemeable),
   Paragraph: () => Promise.resolve(Paragraph),
   Radio: () => Promise.resolve(Radio),
   Spacer: () => Promise.resolve(Spacer),

--- a/tasks/sandbox/components/index.ts
+++ b/tasks/sandbox/components/index.ts
@@ -6,6 +6,7 @@ export const components: TComponents = {
   Heading: () => import('@primitives/heading/meta' /* webpackChunkName: "Heading" */),
   Input: () => import('@primitives/input/meta' /* webpackChunkName: "Input" */),
   LayoutThemeable: () => import('@themeables/layout/meta' /* webpackChunkName: "LayoutThemeable" */),
+  TextAlignThemeable: () => import('@themeables/text-align/meta' /* webpackChunkName: "TextAlignThemeable" */),
   Paragraph: () => import('@primitives/paragraph/meta' /* webpackChunkName: "Paragraph" */),
   Radio: () => import('@primitives/radio/meta' /* webpackChunkName: "Radio" */),
   Spacer: () => import('@primitives/spacer/meta' /* webpackChunkName: "Spacer" */),


### PR DESCRIPTION
New themeable `TextAlignThemeable` to be able to theme Paragraph `align` and `direction` props.
I added example to Sandbox.

The PR also contains small change in Paragraph primitive types to make them easier to reuse in TextAlign themeable.