### PR TITLE
🐞 bubble-dev/start-preset: bring up copying json files in node build before test plugin

### DIFF
--- a/packages/bubble-dev/start-preset/src/build.ts
+++ b/packages/bubble-dev/start-preset/src/build.ts
@@ -101,7 +101,7 @@ export const buildNode = async (dir: string): Promise<StartPlugin<{}, {}>> => {
     write(`${dir}/build/node/`),
     find(`${dir}/src/**/*.json`),
     copy(`${dir}/build/node/`),
-    plugin('test', ({ logMessage }) => async () => {
+    plugin('test', () => async () => {
       const path = await import('path')
       const { access } = await import('pifs')
       const fullPath = path.resolve(`${dir}/build/node/index.js`)

--- a/packages/bubble-dev/start-preset/src/build.ts
+++ b/packages/bubble-dev/start-preset/src/build.ts
@@ -99,7 +99,9 @@ export const buildNode = async (dir: string): Promise<StartPlugin<{}, {}>> => {
     babel(babelConfigNodeBuild),
     rename((file) => file.replace(/\.(ts|tsx|jsx)$/, '.js')),
     write(`${dir}/build/node/`),
-    plugin('test', () => async () => {
+    find(`${dir}/src/**/*.json`),
+    copy(`${dir}/build/node/`),
+    plugin('test', ({ logMessage }) => async () => {
       const path = await import('path')
       const { access } = await import('pifs')
       const fullPath = path.resolve(`${dir}/build/node/index.js`)
@@ -113,9 +115,7 @@ export const buildNode = async (dir: string): Promise<StartPlugin<{}, {}>> => {
       if (hasFile) {
         await import(fullPath)
       }
-    }),
-    find(`${dir}/src/**/*.json`),
-    copy(`${dir}/build/node/`)
+    })
   )
 }
 


### PR DESCRIPTION
Prevent build from failing on not being able to import json file that was not copied yet