### PR TITLE
🌱 bubble-dev/start-preset: support passing template name to the pkg task

### DIFF
--- a/packages/bubble-dev/start-preset/src/pkg.ts
+++ b/packages/bubble-dev/start-preset/src/pkg.ts
@@ -135,7 +135,7 @@ export const Pkg = (replacers?: TReplacers) => (packagePath: string, shouldAddMi
 
     const allReplacers = {
       ...userReplacers,
-      ...(Boolean(name) && { $name$: name }),
+      ...(name !== null && { $name$: name }),
     }
 
     const templatePath = path.join(templatesPath, type)

--- a/packages/bubble-dev/start-preset/src/pkg.ts
+++ b/packages/bubble-dev/start-preset/src/pkg.ts
@@ -24,7 +24,7 @@ export type TReplacers = {
   },
 }
 
-export const Pkg = (replacers?: TReplacers) => (packagePath: string, shouldAddMissingWorkspace: boolean = true, templateName: (string) = '') =>
+export const Pkg = (replacers?: TReplacers) => (packagePath: string, shouldAddMissingWorkspace: boolean = true, templateName: string = '') =>
   plugin('template', ({ logPath, logMessage }) => async () => {
     const { isString } = await import('tsfn')
 

--- a/packages/bubble-dev/start-preset/src/pkg.ts
+++ b/packages/bubble-dev/start-preset/src/pkg.ts
@@ -135,7 +135,7 @@ export const Pkg = (replacers?: TReplacers) => (packagePath: string, shouldAddMi
 
     const allReplacers = {
       ...userReplacers,
-      $name$: name,
+      ...(Boolean(name) && { $name$: name }),
     }
 
     const templatePath = path.join(templatesPath, type)

--- a/packages/bubble-dev/start-preset/src/pkg.ts
+++ b/packages/bubble-dev/start-preset/src/pkg.ts
@@ -24,6 +24,10 @@ export type TReplacers = {
   },
 }
 
+const isThereOnlyOneOption = (options: any[]) => {
+  return (options.length === 1)
+}
+
 export const Pkg = (replacers?: TReplacers) => (packagePath: string, shouldAddMissingWorkspace: boolean = true, templateName: string = '') =>
   plugin('template', ({ logPath, logMessage }) => async () => {
     const { isString } = await import('tsfn')
@@ -67,7 +71,7 @@ export const Pkg = (replacers?: TReplacers) => (packagePath: string, shouldAddMi
     if (Boolean(templateName) && templateNames.includes(templateName)) {
       type = templateName
     } else {
-      if (templateNames.length === 1) {
+      if (isThereOnlyOneOption(templateNames)) {
         type = templateNames[0]
       } else {
         const result = await prompts(


### PR DESCRIPTION
This pr takes care of:
1. Being able to pass the template name in advance
2. Not being prompted for a package name (it was already working automatically, but we were still prompted)