### PR TITLE
🌱 primitives/block: allow block to represent progressbar

### DIFF
--- a/packages/primitives/block/meta.tsx
+++ b/packages/primitives/block/meta.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { TComponentConfig } from 'autoprops'
+import { Text } from '@primitives/text'
+import type { TBlock } from './src'
+
+export const config: TComponentConfig<TBlock, 'items'> = {
+  props: {
+    style: [{ minWidth: 100, minHeight: 40, backgroundColor: '#ffb3c7' }],
+    role: ['main', 'header', 'footer', 'navigation', 'section', 'secondary', 'primary', 'none', 'progressbar'],
+    children: [<Text key="first">Me... a Block</Text>],
+    ariaValuemin: [7],
+    ariaValuenow: [47],
+    ariaValuemax: [99],
+  },
+  required: ['style', 'children'],
+}
+
+export { Block as Component } from './src'
+export { default as packageJson } from './package.json'

--- a/packages/primitives/block/meta.tsx
+++ b/packages/primitives/block/meta.tsx
@@ -8,9 +8,9 @@ export const config: TComponentConfig<TBlock, 'items'> = {
     style: [{ minWidth: 100, minHeight: 40, backgroundColor: '#ffb3c7' }],
     role: ['main', 'header', 'footer', 'navigation', 'section', 'secondary', 'primary', 'none', 'progressbar'],
     children: [<Text key="first">Me... a Block</Text>],
-    ariaValuemin: [7],
-    ariaValuenow: [47],
-    ariaValuemax: [99],
+    ariaValuemin: [0, 15],
+    ariaValuenow: [80, 47],
+    ariaValuemax: [100, 150],
   },
   required: ['style', 'children'],
 }

--- a/packages/primitives/block/package.json
+++ b/packages/primitives/block/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/react": "^16.8.6",
     "@types/react-native": "^0.63.0",
+    "autoprops": "^4.0.1",
     "react": "16.13.1",
     "react-native": "0.63.2"
   }

--- a/packages/primitives/block/package.json
+++ b/packages/primitives/block/package.json
@@ -13,6 +13,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@primitives/text": "^3.0.1",
     "refun": "^3.0.0",
     "stili": "^3.0.1",
     "tsfn": "^2.0.0"

--- a/packages/primitives/block/src/Root.native.tsx
+++ b/packages/primitives/block/src/Root.native.tsx
@@ -42,6 +42,9 @@ export const Block = component(
       shouldIgnorePointerEvents,
       ref,
       role,
+      ariaValuemin,
+      ariaValuenow,
+      ariaValuemax,
     }) => {
       const styles: TStyle = {
         borderStyle: 'solid',
@@ -106,6 +109,15 @@ export const Block = component(
         props.testID = id
       }
 
+      if (ariaValuenow) {
+        props.accessibilityValue = {
+          ...(ariaValuemin ? { min: ariaValuemin } : {}),
+          now: ariaValuenow,
+          ...(ariaValuemax ? { max: ariaValuemax } : {}),
+        }
+        props.accessible = true
+      }
+
       return {
         ...props,
         style: normalizeNativeStyle(styles),
@@ -122,6 +134,9 @@ export const Block = component(
 
     case 'header':
       return <View accessibilityRole="header" {...props}/>
+
+    case 'progressbar':
+      return <View accessibilityRole="progressbar" {...props}/>
 
     default:
       return <View {...props}/>

--- a/packages/primitives/block/src/Root.native.tsx
+++ b/packages/primitives/block/src/Root.native.tsx
@@ -109,11 +109,11 @@ export const Block = component(
         props.testID = id
       }
 
-      if (ariaValuenow) {
+      if (isNumber(ariaValuenow)) {
         props.accessibilityValue = {
-          ...(ariaValuemin ? { min: ariaValuemin } : {}),
+          ...(isNumber(ariaValuemin) ? { min: ariaValuemin } : {}),
           now: ariaValuenow,
-          ...(ariaValuemax ? { max: ariaValuemax } : {}),
+          ...(isNumber(ariaValuemax) ? { max: ariaValuemax } : {}),
         }
         props.accessible = true
       }

--- a/packages/primitives/block/src/Root.tsx
+++ b/packages/primitives/block/src/Root.tsx
@@ -4,7 +4,7 @@ import { normalizeWebStyle } from 'stili'
 import type { TStyle } from 'stili'
 import { component, startWithType, mapDefaultProps, mapProps } from 'refun'
 import { isNumber, isDefined } from 'tsfn'
-import type { TBlock, TBlockRoles } from './types'
+import type { TBlock, TBlockRoles, TProgressBar } from './types'
 
 export const Block = component(
   startWithType<TBlock>(),
@@ -46,6 +46,9 @@ export const Block = component(
       onPointerUp,
       onPointerMove,
       role,
+      ariaValuemin,
+      ariaValuenow,
+      ariaValuemax,
     }) => {
       const styles: TStyle = {
         display: 'flex',
@@ -109,7 +112,7 @@ export const Block = component(
         styles.overflow = 'hidden'
       }
 
-      const props: HTMLProps<HTMLDivElement> & { role: TBlockRoles } = {
+      const props: HTMLProps<HTMLDivElement> & { role: TBlockRoles } & TProgressBar = {
         style: normalizeWebStyle(styles),
         children,
         onMouseEnter: onPointerEnter,
@@ -118,6 +121,9 @@ export const Block = component(
         onMouseUp: onPointerUp,
         onMouseMove: onPointerMove,
         role: 'none',
+        ariaValuemin,
+        ariaValuenow,
+        ariaValuemax,
       }
 
       if (typeof id === 'string') {
@@ -135,7 +141,7 @@ export const Block = component(
       return props
     }
   )
-)(({ role, ...props }) => {
+)(({ role, ariaValuenow, ariaValuemax, ariaValuemin, ...props }) => {
   switch (role) {
     case 'main':
       return <main {...props}/>
@@ -151,6 +157,16 @@ export const Block = component(
       return <aside {...props}/>
     case 'primary':
       return <article {...props}/>
+    case 'progressbar':
+      return (
+        <div
+          role={'progressbar'}
+          {...ariaValuenow ? { 'aria-valuenow': ariaValuenow } : {}}
+          {...ariaValuemax ? { 'aria-valuemax': ariaValuemax } : {}}
+          {...ariaValuemin ? { 'aria-valuemin': ariaValuemin } : {}}
+          {...props}
+        />
+      )
     case 'none':
     default:
       return <div {...props}/>

--- a/packages/primitives/block/src/Root.tsx
+++ b/packages/primitives/block/src/Root.tsx
@@ -161,9 +161,9 @@ export const Block = component(
       return (
         <div
           role={'progressbar'}
-          {...ariaValuenow ? { 'aria-valuenow': ariaValuenow } : {}}
-          {...ariaValuemax ? { 'aria-valuemax': ariaValuemax } : {}}
-          {...ariaValuemin ? { 'aria-valuemin': ariaValuemin } : {}}
+          {...isNumber(ariaValuenow) ? { 'aria-valuenow': ariaValuenow } : {}}
+          {...isNumber(ariaValuemin) ? { 'aria-valuemin': ariaValuemin } : {}}
+          {...isNumber(ariaValuemax) ? { 'aria-valuemax': ariaValuemax } : {}}
           {...props}
         />
       )

--- a/packages/primitives/block/src/types.ts
+++ b/packages/primitives/block/src/types.ts
@@ -1,7 +1,13 @@
 import type { ReactNode, Ref } from 'react'
 import type { TStyle } from 'stili'
 
-export type TBlockRoles = 'main' | 'header' | 'footer' | 'navigation' | 'section' | 'secondary' | 'primary' | 'none'
+export type TProgressBar = {
+  ariaValuemin?: number,
+  ariaValuenow?: number,
+  ariaValuemax?: number,
+}
+
+export type TBlockRoles = 'main' | 'header' | 'footer' | 'navigation' | 'section' | 'secondary' | 'primary' | 'none' | 'progressbar'
 
 export type TBlock = {
   id?: string,
@@ -31,4 +37,4 @@ export type TBlock = {
   onPointerDown?: () => void,
   onPointerUp?: () => void,
   onPointerMove?: () => void,
-}
+} & TProgressBar

--- a/tasks/sandbox/components/index.native.ts
+++ b/tasks/sandbox/components/index.native.ts
@@ -14,6 +14,7 @@ import * as Spacer from '@primitives/spacer/meta'
 // import * as TestLottie from 'test-lottie/meta'
 import * as VectorShape from '@primitives/vector-shape/meta'
 import * as List from '@primitives/list/meta'
+import * as Block from '@primitives/block/meta'
 
 export const components: TComponents = {
   Background: () => Promise.resolve(Background),
@@ -30,4 +31,5 @@ export const components: TComponents = {
   Radio: () => Promise.resolve(Radio),
   Spacer: () => Promise.resolve(Spacer),
   List: () => Promise.resolve(List),
+  Block: () => Promise.resolve(Block),
 }

--- a/tasks/sandbox/components/index.ts
+++ b/tasks/sandbox/components/index.ts
@@ -16,4 +16,5 @@ export const components: TComponents = {
   Radio: () => import('@primitives/radio/meta' /* webpackChunkName: "Radio" */),
   Spacer: () => import('@primitives/spacer/meta' /* webpackChunkName: "Spacer" */),
   List: () => import('@primitives/list/meta' /* webpackChunkName: "List" */),
+  Block: () => import('@primitives/block/meta' /* webpackChunkName: "List" */),
 }


### PR DESCRIPTION
block now accept props for progressbar
you can see the use case here: https://www.notion.so/klarnadesign/Bubble-next-Accessibility-81d1cc3a00a945e6a3f8ddab1d2cea1b

<img width="975" alt="Screenshot 2021-01-20 at 11 56 01" src="https://user-images.githubusercontent.com/16437281/105165693-f1daf980-5b16-11eb-88b9-890c7792c305.png">


second approach to progress bar a11y can be found here: https://github.com/bubble-dev/_/pull/469