### PR TITLE
Make build accept node files

### DIFF
--- a/packages/bubble-dev/start-preset/src/build.ts
+++ b/packages/bubble-dev/start-preset/src/build.ts
@@ -30,7 +30,7 @@ export const buildWeb = async (dir: string): Promise<StartPlugin<{}, {}>> => {
   return sequence(
     find([
       `${dir}/src/**/*.{js,jsx,ts,tsx}`,
-      `!${dir}/src/**/*.{native,ios,android}.{js,jsx,ts,tsx}`,
+      `!${dir}/src/**/*.{node,native,ios,android}.{js,jsx,ts,tsx}`,
       `!${dir}/src/**/*.d.ts`,
     ]),
     read,

--- a/packages/bubble-dev/start-preset/src/build.ts
+++ b/packages/bubble-dev/start-preset/src/build.ts
@@ -115,7 +115,7 @@ export const buildNode = async (dir: string): Promise<StartPlugin<{}, {}>> => {
       read,
       env({ BABEL_ENV: 'production' }),
       babel(babelConfigNodeBuild),
-      rename((file) => file.replace(/(\.node)?\.(ts|tsx|jsx)$/, '.js')),
+      rename((file) => file.replace(/(\.node)?\.(ts|tsx|jsx|js)$/, '.js')),
       write(`${dir}/build/node/`),
       find(`${dir}/src/**/*.json`),
       copy(`${dir}/build/node/`),

--- a/packages/bubble-dev/start-preset/src/build.ts
+++ b/packages/bubble-dev/start-preset/src/build.ts
@@ -48,6 +48,7 @@ export const buildReactNative = async (dir: string): Promise<StartPlugin<{}, {}>
   const allFiles = await globby(
     [
       `${dir}/src/**/*.{js,jsx,ts,tsx}`,
+      `!${dir}/src/**/*.node.{js,jsx,ts,tsx}`,
       `!${dir}/src/**/*.d.ts`,
     ],
     {


### PR DESCRIPTION
Make build system support files with `.node.(jsx|js|ts|tsx)` extensions, use them for node build and ignore them in other builds.
I tested it by building all the packages in this repo and other huge, private repo 😉 

------------- BEFORE -------------------------------- AFTER ------------
![image](https://user-images.githubusercontent.com/13185981/105520363-eafce400-5cda-11eb-9c68-f432cee8734b.png)
