### PR TITLE
🐞 bubble-dev/start-preset: fix typescript

### DIFF
--- a/packages/bubble-dev/start-preset/src/plugins/sync-state.ts
+++ b/packages/bubble-dev/start-preset/src/plugins/sync-state.ts
@@ -6,7 +6,7 @@ const PORT = 3001
 export default plugin<{}, void>('syncState', ({ logMessage }) => async () => {
   const { default: WebSocket } = await import('ws')
 
-  await new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     const wss = new WebSocket.Server({
       host: HOST,
       port: PORT,


### PR DESCRIPTION
currently we have in our package.json "typesctipt": "^4.0.3"
it allows (after running yarn) to be updated to version 4.1.3

see https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#resolves-parameters-are-no-longer-optional-in-promises

when we on version 4.1.3 we get this lint error:

```
packages/bubble-dev/start-preset/src/plugins/sync-state.ts:71:7 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?

71       resolve()
         ~~~~~~~~~

  node_modules/typescript/lib/lib.es2015.promise.d.ts:33:34
    33     new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'value' was not provided.


Found 1 error.

lint.typescriptCheck: error
lint.sequence: error
```

this PR fix it