### PR TITLE
🐞 sandbox/ui: show function name in sandbox component controls

### DIFF
--- a/packages/sandbox/ui/src/components/component-controls/print-value.ts
+++ b/packages/sandbox/ui/src/components/component-controls/print-value.ts
@@ -5,7 +5,7 @@ import { getElementName } from '../../utils'
 
 const REACT_FRAGMENT_TYPE = Symbol.for('react.fragment')
 
-export const printValue = (value?: ReactElement<any> | string | number | symbol): string => {
+export const printValue = (value?: ReactElement<any> | string | number | symbol | React.FC): string => {
   if (isUndefined(value)) {
     return '{undefined}'
   }
@@ -23,7 +23,7 @@ export const printValue = (value?: ReactElement<any> | string | number | symbol)
   }
 
   if (isFunction(value)) {
-    return '{() => {}}'
+    return value.displayName ? value.displayName : (value.name ? value.name : '{() => {}}')
   }
 
   if (isValidElement(value) && value.type as any === REACT_FRAGMENT_TYPE) {

--- a/packages/sandbox/ui/src/components/component-controls/print-value.ts
+++ b/packages/sandbox/ui/src/components/component-controls/print-value.ts
@@ -23,8 +23,14 @@ export const printValue = (value?: ReactElement<any> | string | number | symbol 
   }
 
   if (isFunction(value)) {
-    if (value.displayName) return value.displayName
-    if (value.name) return value.name
+    if (value.displayName) {
+      return value.displayName
+    }
+
+    if (value.name) {
+      return value.name
+    }
+
     return '{() => {}}'
   }
 

--- a/packages/sandbox/ui/src/components/component-controls/print-value.ts
+++ b/packages/sandbox/ui/src/components/component-controls/print-value.ts
@@ -23,7 +23,9 @@ export const printValue = (value?: ReactElement<any> | string | number | symbol 
   }
 
   if (isFunction(value)) {
-    return value.displayName ? value.displayName : (value.name ? value.name : '{() => {}}')
+    if (value.displayName) return value.displayName
+    if (value.name) return value.name
+    return '{() => {}}'
   }
 
   if (isValidElement(value) && value.type as any === REACT_FRAGMENT_TYPE) {


### PR DESCRIPTION
Until now every function was shown as `() => {}` in sandbox ComponentControls area, now we show the function `name`, or `displayName` for components, if its an anonymous function it stays the same as before

some food for your eyes:
<img width="1576" alt="Screenshot 2021-03-05 at 16 42 27" src="https://user-images.githubusercontent.com/16437281/110138890-bcdaeb80-7dd2-11eb-993d-00099136a01f.png">
