### PR TITLE
allow false values for component in sandbox

### DIFF
--- a/packages/sandbox/ui/src/components/component-controls/PropsItem.tsx
+++ b/packages/sandbox/ui/src/components/component-controls/PropsItem.tsx
@@ -65,6 +65,7 @@ export const PropsItem = pureComponent(
           {isCheckboxValues(possibleValues)
             ? (
               <ValueCheckbox
+                propPossibleValues={possibleValues}
                 propPath={propPath}
                 propValue={value}
                 checkedPropValue

--- a/packages/sandbox/ui/src/components/component-controls/ValueCheckbox.tsx
+++ b/packages/sandbox/ui/src/components/component-controls/ValueCheckbox.tsx
@@ -38,7 +38,18 @@ export const ValueCheckbox = pureComponent(
     onChange: ({ propPath, checkedPropValue, onChange, isChecked, setIsChecked, onOptimisticWait, shouldShowFalseValue }) => () => {
       setIsChecked(!isChecked)
       onOptimisticWait()
-      onChange(propPath, isChecked ? shouldShowFalseValue? false : undefined : checkedPropValue)
+
+      let onChangeValue = checkedPropValue
+
+      if (isChecked) {
+        if (shouldShowFalseValue) {
+          onChangeValue = false
+        } else {
+          onChangeValue = undefined
+        }
+      }
+
+      onChange(propPath, onChangeValue)
     },
   })
 )(({ isChecked, onChange }) => (

--- a/packages/sandbox/ui/src/components/component-controls/print-value.ts
+++ b/packages/sandbox/ui/src/components/component-controls/print-value.ts
@@ -5,7 +5,7 @@ import { getElementName } from '../../utils'
 
 const REACT_FRAGMENT_TYPE = Symbol.for('react.fragment')
 
-export const printValue = (value?: ReactElement<any> | string | number | symbol): string => {
+export const printValue = (value?: ReactElement<any> | string | number | symbol | React.FC): string => {
   if (isUndefined(value)) {
     return '{undefined}'
   }
@@ -23,7 +23,7 @@ export const printValue = (value?: ReactElement<any> | string | number | symbol)
   }
 
   if (isFunction(value)) {
-    return '{() => {}}'
+    return value.displayName ? value.displayName : (value.name ? value.name : '{() => {}}')
   }
 
   if (isValidElement(value) && value.type as any === REACT_FRAGMENT_TYPE) {

--- a/packages/sandbox/ui/src/components/component-controls/print-value.ts
+++ b/packages/sandbox/ui/src/components/component-controls/print-value.ts
@@ -23,8 +23,14 @@ export const printValue = (value?: ReactElement<any> | string | number | symbol 
   }
 
   if (isFunction(value)) {
-    if (value.displayName) return value.displayName
-    if (value.name) return value.name
+    if (value.displayName) {
+      return value.displayName
+    }
+
+    if (value.name) {
+      return value.name
+    }
+
     return '{() => {}}'
   }
 

--- a/packages/sandbox/ui/src/components/component-controls/print-value.ts
+++ b/packages/sandbox/ui/src/components/component-controls/print-value.ts
@@ -23,7 +23,9 @@ export const printValue = (value?: ReactElement<any> | string | number | symbol 
   }
 
   if (isFunction(value)) {
-    return value.displayName ? value.displayName : (value.name ? value.name : '{() => {}}')
+    if (value.displayName) return value.displayName
+    if (value.name) return value.name
+    return '{() => {}}'
   }
 
   if (isValidElement(value) && value.type as any === REACT_FRAGMENT_TYPE) {


### PR DESCRIPTION
we have some anti-pattern props in bubble-ui by default they are "true" and we accept the "false" value from the user when need
this could not be reflected in Storybook and we had to use fake-props in order to achieve it, no more!

before:
<img width="936" alt="Screenshot 2021-03-12 at 15 35 33" src="https://user-images.githubusercontent.com/16437281/110956458-ef449580-834a-11eb-8a0c-cb81c90a206e.png">


Now:
<img width="916" alt="Screenshot 2021-03-12 at 15 36 48" src="https://user-images.githubusercontent.com/16437281/110956471-f2d81c80-834a-11eb-9a96-0bc673a3d44b.png">

