### PR TITLE
show false values in sandbox

### DIFF
--- a/packages/sandbox/ui/src/components/component-controls/PropsItem.tsx
+++ b/packages/sandbox/ui/src/components/component-controls/PropsItem.tsx
@@ -65,6 +65,7 @@ export const PropsItem = pureComponent(
           {isCheckboxValues(possibleValues)
             ? (
               <ValueCheckbox
+                propPossibleValues={possibleValues}
                 propPath={propPath}
                 propValue={value}
                 checkedPropValue

--- a/packages/sandbox/ui/src/components/component-controls/ValueCheckbox.tsx
+++ b/packages/sandbox/ui/src/components/component-controls/ValueCheckbox.tsx
@@ -13,12 +13,12 @@ export type TValueCheckboxProps = {
 
 const isDefined = (val: any): boolean => val !== false && val !== undefined
 
-const hasFalseInPosiibleValues = (propPossibleValues: readonly any[]): boolean => propPossibleValues.length === 2 && propPossibleValues.includes(true) && propPossibleValues.includes(false)
+const hasBothTrueAndFalseValues = (propPossibleValues: readonly any[]): boolean => propPossibleValues.length === 2 && propPossibleValues.includes(true) && propPossibleValues.includes(false)
 
 export const ValueCheckbox = pureComponent(
   startWithType<TValueCheckboxProps>(),
   mapWithProps(({ propPossibleValues, propValue }) => {
-    const valueCanBeFalse = propPossibleValues && hasFalseInPosiibleValues(propPossibleValues)
+    const valueCanBeFalse = propPossibleValues && hasBothTrueAndFalseValues(propPossibleValues)
 
     return (
       {

--- a/packages/sandbox/ui/src/components/component-controls/ValueCheckbox.tsx
+++ b/packages/sandbox/ui/src/components/component-controls/ValueCheckbox.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { startWithType, mapHandlers, pureComponent, mapState, mapDebouncedHandlerTimeout } from 'refun'
+import { startWithType, mapHandlers, pureComponent, mapState, mapDebouncedHandlerTimeout, mapWithProps } from 'refun'
 import { Switch } from '../switch'
 import { SYMBOL_SWITCH } from '../../symbols'
 
@@ -7,13 +7,26 @@ export type TValueCheckboxProps = {
   propPath: readonly string[],
   checkedPropValue: any,
   propValue: any,
+  propPossibleValues?: readonly any[],
   onChange: (propPath: readonly string[], propValue: any) => void,
 }
 
 const isDefined = (val: any): boolean => val !== false && val !== undefined
 
+const hasFalseInPosiibleValues = (propPossibleValues: readonly any[]): boolean => propPossibleValues.length === 2 && propPossibleValues.includes(true) && propPossibleValues.includes(false)
+
 export const ValueCheckbox = pureComponent(
   startWithType<TValueCheckboxProps>(),
+  mapWithProps(({ propPossibleValues, propValue }) => {
+    const valueCanBeFalse = propPossibleValues && hasFalseInPosiibleValues(propPossibleValues)
+
+    return (
+      {
+        valueCanBeFalse,
+        propValue: valueCanBeFalse && propValue === undefined ? true : propValue,
+      }
+    )
+  }),
   mapState('isChecked', 'setIsChecked', ({ propValue }) => isDefined(propValue), ['propValue']),
   mapHandlers({
     onOptimisticWait: ({ propValue, isChecked, setIsChecked }) => () => {
@@ -26,10 +39,21 @@ export const ValueCheckbox = pureComponent(
   }),
   mapDebouncedHandlerTimeout('onOptimisticWait', 500),
   mapHandlers({
-    onChange: ({ propPath, checkedPropValue, onChange, isChecked, setIsChecked, onOptimisticWait }) => () => {
+    onChange: ({ propPath, checkedPropValue, onChange, isChecked, setIsChecked, onOptimisticWait, valueCanBeFalse }) => () => {
       setIsChecked(!isChecked)
       onOptimisticWait()
-      onChange(propPath, isChecked ? undefined : checkedPropValue)
+
+      let onChangeValue = checkedPropValue
+
+      if (isChecked) {
+        if (valueCanBeFalse) {
+          onChangeValue = false
+        } else {
+          onChangeValue = undefined
+        }
+      }
+
+      onChange(propPath, onChangeValue)
     },
   })
 )(({ isChecked, onChange }) => (


### PR DESCRIPTION
we have some anti-pattern props in bubble-ui by default they are "true" and we accept the "false" value from the user when need
this could not be reflected in Storybook and we had to use fake-props in order to achieve it, no more!

before:
<img width="936" alt="Screenshot 2021-03-12 at 15 35 33" src="https://user-images.githubusercontent.com/16437281/110956458-ef449580-834a-11eb-8a0c-cb81c90a206e.png">


Now:
<img width="916" alt="Screenshot 2021-03-12 at 15 36 48" src="https://user-images.githubusercontent.com/16437281/110956471-f2d81c80-834a-11eb-9a96-0bc673a3d44b.png">

