### PR TITLE
🛠 fix for xcode 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "typescript": "^4.1.3"
   },
   "scripts": {
-    "start": "packages/bubble-dev/start-preset/src/cli/index.js"
+    "start": "packages/bubble-dev/start-preset/src/cli/index.js",
+    "postinstall": "perl -pi -e \"s/'React'/'React-Core'/g\" ./node_modules/react-native-svg/RNSVG.podspec ./node_modules/lottie-react-native/lottie-react-native.podspec"
   },
   "start": {
     "file": "tasks/",


### PR DESCRIPTION
I was trying to use @rebox on Xcode 12.4 with additional dependencies `react-native-svg` and `lottie-react-native`, but it was resulting in an errors like this one:

```
The following build commands failed:
        Ld /Users/user.name/Library/Developer/Xcode/DerivedData/rebox-byjvpkhoayqrwpfsuipmqmyqgpzv/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/RNSVG.build/Objects-normal/x86_64/Binary/RNSVG normal x86_64
(1 failure)

```

After some research, I found that this specific fix seems to work:[react-native-svg/react-native-svg#1510](https://github.com/react-native-svg/react-native-svg/issues/1510)
(replacing 'React' with 'React-Core' inside `./node_modules/react-native-svg/RNSVG.podspec` and other respective podspec files)

So far adding a simple postinstall script seems to be fastest solution:

```
  "scripts": {
    "postinstall": "perl -pi -e \"s/'React'/'React-Core'/g\" ./node_modules/react-native-svg/RNSVG.podspec ./node_modules/lottie-react-native/lottie-react-native.podspec"
  },

```

Works on ios and android, tests pass locally, svgs and animations work 👍 